### PR TITLE
fix yarn install error on fresh install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
-//npm.pkg.github.com/:_authToken=${SANCTUARYTEAM_AUTH_TOKEN}
+npm config set '//npm.pkg.github.com/:_authToken' "${SANCTUARYTEAM_AUTH_TOKEN}"
 @sanctuaryteam:registry=https://npm.pkg.github.com
 always-auth=true


### PR DESCRIPTION
Fixes the error `error An unexpected error occurred: "Failed to replace env in config: ${SANCTUARYTEAM_AUTH_TOKEN}".` when attempting to `yarn install` a freshly cloned repo.

Source: https://stackoverflow.com/a/55610612